### PR TITLE
Trust-proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ let parameters = {
 };
 if (process.env.NODE_ENV === 'production') {
     parameters.sessionStore = new MongoStore({url: process.env.MONGO_URI});
+    parameters.secureCookies = false;
 }
 const keystone = new Keystone(parameters);
 


### PR DESCRIPTION
отключил secureCookies для корректной работы авторизации при проксировании nginx